### PR TITLE
Use Byte.toUnsignedInt(byte)

### DIFF
--- a/entropy.java
+++ b/entropy.java
@@ -36,7 +36,7 @@ class entropy {
 	    // count frequency of occuring bytes
             for(int i=0; i<fileContentLength; i++) {
 		byte byteValue=fileContent[i];
-		frequency_array[byteValue]++;
+		frequency_array[Byte.toUnsignedInt(byteValue)]++;
 	    }
             
 	    // calculate entropy


### PR DESCRIPTION
This prevents an ArrayIndexOutOfBoundsException for bytes that have a negative sign.

byte b = -1;
int i = b; // i is negative 1, not 255
int j = Byte.toUnsignedInt(b); // j is 255